### PR TITLE
Fix for `iis_pool` server-level app pool default value inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the iis cookbook.
 
 ## Unreleased
 
+- Fixed `iis_pool` server-level app pool default value inheritance
+
 ## 7.4.0 - *2021-01-10*
 
 - Adoption by Sous-chefs

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -194,7 +194,7 @@ action :add do
       cmd << ' /commit:\"MACHINE/WEBROOT/APPHOST\"'
       Chef::Log.debug(cmd)
       shell_out!(cmd)
-      configure
+      action_config
     end
   end
 end

--- a/test/cookbooks/test/recipes/pool.rb
+++ b/test/cookbooks/test/recipes/pool.rb
@@ -18,6 +18,12 @@
 
 include_recipe 'iis'
 
+# Defines default app pool recycle time(s)
+iis_config "/section:system.applicationHost/applicationPools /+\"applicationPoolDefaults.recycling.periodicRestart.schedule.[value='06:00:00']\" /commit:apphost" do
+  returns [0, 183]
+  action :set
+end
+
 directory "#{node['iis']['docroot']}\\test" do
   recursive true
 end


### PR DESCRIPTION
# Description

Updated `:add` action to call `:config` action so that server-level pool defaults that are inherited are discovered properly in `load_current_value`

## Issues Resolved

Fixes #473

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
