### PR TITLE
Support pool setting 'recycling.periodicRestart.requests'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the iis cookbook.
 - Change CI to test on Windows Latest
   This clarfies that we are testing on the latest version of Windows and not a specific version
   as per `platform: windows-latest` in ci.yml
+- Add support for IIS pool setting `recycling.periodicRestart.requests`
 
 ## 8.1.0 - *2023-10-03*
 

--- a/documentation/iis_pool.md
+++ b/documentation/iis_pool.md
@@ -62,6 +62,7 @@ Creates an application pool in IIS.
 | `recycle_schedule_clear`              |  String         | `false`     | No        | specifies a pool to clear all scheduled recycle times. | |
 | `log_event_on_recycle`                |  true, false    | `node['iis']['recycle']['log_events']`| No        | configure IIS to log an event when one or more of the following configured events cause an application pool to recycle (for additional information about [logging events] (<https://technet.microsoft.com/en-us/library/cc771318%28v=ws.10%29.aspx>). | |
 | `recycle_after_time`                  |  String         |             | No        | specifies a pool to recycle at regular time intervals, d.hh:mm:ss. | |
+| `recycle_after_requests`              |  Integer        |             | No        | specifies the number of requests after which you want the pool to recycle. | |
 | `periodic_restart_schedule`           |  Array, String  |             | No        | schedule a pool to recycle at specific times. | |
 | `private_memory`                      |  Integer        |             | No        | specifies the amount of private memory (in kilobytes) after which you want the pool to recycle. | |
 | `virtual_memory`                      |  Integer        |             | No        | specifies the amount of virtual memory (in kilobytes) after which you want the pool to recycle. | |

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -60,6 +60,7 @@ property :disallow_overlapping_rotation, [true, false], default: false
 property :recycle_schedule_clear, [true, false], default: false
 property :log_event_on_recycle, String, default: lazy { node['iis']['recycle']['log_events'] }
 property :recycle_after_time, String
+property :recycle_after_requests, Integer, coerce: proc { |v| v.to_i }
 property :periodic_restart_schedule, [Array, String], default: [], coerce: proc { |v| Array(v).sort }
 property :private_memory, Integer, coerce: proc { |v| v.to_i }
 property :virtual_memory, Integer, coerce: proc { |v| v.to_i }
@@ -150,6 +151,7 @@ load_current_value do |desired|
     disallow_overlapping_rotation bool(value(doc.root, 'APPPOOL/add/recycling/@disallowOverlappingRotation'))
     disallow_rotation_on_config_change bool(value(doc.root, 'APPPOOL/add/recycling/@disallowRotationOnConfigChange'))
     recycle_after_time value doc.root, 'APPPOOL/add/recycling/periodicRestart/@time'
+    recycle_after_requests value(doc.root, 'APPPOOL/add/recycling/periodicRestart/@requests').to_i
     periodic_restart_schedule get_value(doc.root, 'APPPOOL/add/recycling/periodicRestart/schedule/add/@value').map(&:value)
     private_memory value(doc.root, 'APPPOOL/add/recycling/periodicRestart/@privateMemory').to_i
     virtual_memory value(doc.root, 'APPPOOL/add/recycling/periodicRestart/@memory').to_i
@@ -351,7 +353,9 @@ action_class do
     converge_if_changed :recycle_after_time do
       cmd << configure_application_pool("recycling.periodicRestart.time:#{new_resource.recycle_after_time}")
     end
-
+    converge_if_changed :recycle_after_requests do
+      cmd << configure_application_pool("recycling.periodicRestart.requests:#{new_resource.recycle_after_requests}")
+    end
     converge_if_changed :log_event_on_recycle do
       cmd << configure_application_pool("recycling.logEventOnRecycle:#{new_resource.log_event_on_recycle}")
     end

--- a/test/cookbooks/test/recipes/pool.rb
+++ b/test/cookbooks/test/recipes/pool.rb
@@ -53,6 +53,7 @@ iis_pool 'testapppool' do
   start_mode :OnDemand
   identity_type :SpecificUser
   periodic_restart_schedule ['06:00:00', '14:00:00', '17:00:00']
+  recycle_after_requests '1024'
   environment_variables ['HELLO=WORLD', 'FOO=BAR', 'ALPHA=BETA2']
   username "#{node['hostname']}\\vagrant"
   password 'vagrant'

--- a/test/integration/pool/controls/pool_spec.rb
+++ b/test/integration/pool/controls/pool_spec.rb
@@ -26,6 +26,7 @@ describe iis_pool('testapppool') do
   its('start_mode') { should eq 'OnDemand' }
   its('identity_type') { should eq 'SpecificUser' }
   its('periodic_restart_schedule') { should eq ['06:00:00', '14:00:00', '17:00:00'] }
+  its('recycle_after_requests') { should eq 1024 }
   its('environment_variables') { should eq ['ALPHA=BETA2', 'FOO=BAR', 'HELLO=WORLD'] }
   its('username') { should include('\\vagrant') }
   its('password') { should eq 'vagrant' }

--- a/test/integration/pool/libraries/iis_pool.rb
+++ b/test/integration/pool/libraries/iis_pool.rb
@@ -100,6 +100,10 @@ class IisPool < Inspec.resource(1)
     iis_pool[:recycling][:periodic_restart][:schedule]
   end
 
+  def recycle_after_requests
+    iis_pool[:recycling][:periodic_restart][:requests]
+  end
+
   def environment_variables
     iis_pool[:environment_variables]
   end


### PR DESCRIPTION
# Description

Adds support for setting pool property `recycling.periodicRestart.requests`

Setting this property is a STIG requirement.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
